### PR TITLE
Default users to use rubygems for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a gem wrapper for TextRazor REST API reference.
 
 Add this line to your application's Gemfile:
 
-    gem 'textrazor', :git => 'git://github.com/andhapp/textrazor.git'
+    gem 'textrazor'
 
 And then execute:
 


### PR DESCRIPTION
As this gem is available on rubygems it is customary to suggest installing from there. This allows to easily pin a specific vesion (Gemfile.lock etc.) and feels better ;)

Or is there any reason to use master branch from github instead?