### PR TITLE
Added support for Europe API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ TextRazor.configure do |config|
 end
 ```
 
+You can also force TextRazor to use the European API endpoint if your account
+supports it. You can find more information about this feature in [this blog
+post](https://www.textrazor.com/blog/2018/11/new-region-textrazor-eu.html).
+
+```
+TextRazor.configure do |config|
+  config.use_europe_endpoint = true
+end
+```
+
 ### When the client is persisted across different requests
 
 ```

--- a/lib/textrazor/configuration.rb
+++ b/lib/textrazor/configuration.rb
@@ -1,9 +1,23 @@
 module TextRazor
+
   class Configuration
-    attr_accessor :secure
+    DEFAULT_ENDPOINT = "api.textrazor.com"
+    EUROPE_ENDPOINT = "api-eu.textrazor.com"
+
+    attr_accessor :secure, :use_europe_endpoint
 
     def initialize
       @secure = true
+      @use_europe_endpoint = false
     end
+
+    def url
+      URI::Generic.build(
+        host: (use_europe_endpoint ? EUROPE_ENDPOINT : DEFAULT_ENDPOINT),
+        scheme: (secure ? "https" : "http")
+      ).to_s
+    end
+
   end
+
 end

--- a/lib/textrazor/request.rb
+++ b/lib/textrazor/request.rb
@@ -4,9 +4,6 @@ module TextRazor
 
   class Request
 
-    HTTP_URL = 'http://api.textrazor.com/'
-    HTTPS_URL = 'https://api.textrazor.com/'
-
     OPTIONS_MAPPING = {
       extractors: 'extractors',
       cleanup_mode: 'cleanup.mode',
@@ -22,11 +19,11 @@ module TextRazor
     }
 
     def self.post(text, options)
-      ::RestClient.post url, build_query(text, options), accept_encoding: 'gzip'
-    end
-
-    def self.url
-      TextRazor.configuration.secure ? HTTPS_URL : HTTP_URL
+      ::RestClient.post(
+        TextRazor.configuration.url,
+        build_query(text, options),
+        accept_encoding: 'gzip'
+      )
     end
 
     private

--- a/spec/lib/textrazor/configuration_spec.rb
+++ b/spec/lib/textrazor/configuration_spec.rb
@@ -16,4 +16,37 @@ module TextRazor
       end
     end
   end
+
+  describe "#use_europe_endpoint" do
+    it "default value is false" do
+      Configuration.new.use_europe_endpoint = false
+    end
+  end
+
+  describe "#use_europe_endpoint=" do
+    it "can set value" do
+      config = Configuration.new
+      config.use_europe_endpoint = true
+      expect(config.use_europe_endpoint).to eq(true)
+    end
+  end
+
+  describe "#url" do
+    it "right default value" do
+      config = Configuration.new
+      expect(config.url).to eq("https://api.textrazor.com")
+    end
+
+    it "right value when not secure" do
+      config = Configuration.new
+      config.secure = false
+      expect(config.url).to eq("http://api.textrazor.com")
+    end
+
+    it "right value when Europe endpoint is forced" do
+      config = Configuration.new
+      config.use_europe_endpoint = true
+      expect(config.url).to eq("https://api-eu.textrazor.com")
+    end
+  end
 end

--- a/spec/lib/textrazor/request_spec.rb
+++ b/spec/lib/textrazor/request_spec.rb
@@ -4,40 +4,6 @@ module TextRazor
 
   describe Request do
 
-    describe ".url" do
-      after :each do
-        TextRazor.reset
-      end
-
-      let(:url) do
-        TextRazor::Request.url
-      end
-
-      context "with the config 'secure' set to false" do
-        before :each do
-          TextRazor.configure do |config|
-            config.secure = false
-          end
-        end
-
-        it "returns the unsecured URL" do
-          expect(url).to eq 'http://api.textrazor.com/'
-        end
-      end
-
-      context "with the config 'secure' set to true" do
-        before :each do
-          TextRazor.configure do |config|
-            config.secure = true
-          end
-        end
-
-        it "returns the unsecured URL" do
-          expect(url).to eq 'https://api.textrazor.com/'
-        end
-      end
-    end
-
     context ".post" do
 
       context "default options" do
@@ -46,7 +12,7 @@ module TextRazor
           options = {api_key: 'api_key', extractors: %w(entities topics words dependency-trees relations entailments)}
 
           expect(::RestClient).to receive(:post).
-            with("https://api.textrazor.com/", { "text" => 'text', "apiKey" => 'api_key',
+            with("https://api.textrazor.com", { "text" => 'text', "apiKey" => 'api_key',
             "extractors" => "entities,topics,words,dependency-trees,relations,entailments" }, accept_encoding: 'gzip')
 
           Request.post('text', options)
@@ -63,7 +29,7 @@ module TextRazor
                      enrichment_queries: 'queries', classifiers: 'textrazor_iab'}
 
           expect(::RestClient).to receive(:post).
-            with("https://api.textrazor.com/", { "text" => 'text', "apiKey" => 'api_key', "extractors" => "entities,topics,words",
+            with("https://api.textrazor.com", { "text" => 'text', "apiKey" => 'api_key', "extractors" => "entities,topics,words",
             "cleanup.mode" => "raw", "cleanup.returnCleaned" => true, "cleanup.returnRaw" => true, "languageOverride" => 'fre',
             "entities.filterDbpediaTypes" => "type1", "entities.filterFreebaseTypes" => "type2" , "entities.allowOverlap" => false,
             "entities.enrichmentQueries" => "queries", "classifiers" => 'textrazor_iab'},


### PR DESCRIPTION
Hi,

Since November 2018, TextRazor added a European endpoint to its API] in order to comply with the new GDPR law. See [this blog post](https://www.textrazor.com/blog/2018/11/new-region-textrazor-eu.html) for further details.

This PR adds support for this feature through a new configuration option.

## Important note

This PR conflicts with #10. Depending on which PR gets merged first, I will need to rebase the other one and add some modifications in order to maintain consistency in the codebase.