### PR TITLE
Do not use gzip, invalid byte sequence in UTF-8 (ArgumentError)

### DIFF
--- a/lib/textrazor/request.rb
+++ b/lib/textrazor/request.rb
@@ -21,8 +21,7 @@ module TextRazor
     def self.post(text, options)
       ::RestClient.post(
         TextRazor.configuration.url,
-        build_query(text, options),
-        accept_encoding: 'gzip'
+        build_query(text, options)
       )
     end
 

--- a/spec/lib/textrazor/request_spec.rb
+++ b/spec/lib/textrazor/request_spec.rb
@@ -13,7 +13,7 @@ module TextRazor
 
           expect(::RestClient).to receive(:post).
             with("https://api.textrazor.com", { "text" => 'text', "apiKey" => 'api_key',
-            "extractors" => "entities,topics,words,dependency-trees,relations,entailments" }, accept_encoding: 'gzip')
+            "extractors" => "entities,topics,words,dependency-trees,relations,entailments" })
 
           Request.post('text', options)
         end
@@ -32,8 +32,7 @@ module TextRazor
             with("https://api.textrazor.com", { "text" => 'text', "apiKey" => 'api_key', "extractors" => "entities,topics,words",
             "cleanup.mode" => "raw", "cleanup.returnCleaned" => true, "cleanup.returnRaw" => true, "languageOverride" => 'fre',
             "entities.filterDbpediaTypes" => "type1", "entities.filterFreebaseTypes" => "type2" , "entities.allowOverlap" => false,
-            "entities.enrichmentQueries" => "queries", "classifiers" => 'textrazor_iab'},
-             accept_encoding: 'gzip')
+            "entities.enrichmentQueries" => "queries", "classifiers" => 'textrazor_iab'})
 
           Request.post('text', options)
         end


### PR DESCRIPTION
Hi. I'm using this gem in ruby 2.7.0. It gives this error:
```
irb(main):001:0> require 'textrazor'
=> true
irb(main):002:0> client = TextRazor::Client.new('...')
irb(main):003:0> client.analyse('Bill Gates is a co-founder of Microsoft')
Traceback (most recent call last):
        9: from /usr/local/bin/irb:23:in `<main>'
        8: from /usr/local/bin/irb:23:in `load'
        7: from /usr/local/lib/ruby/gems/2.7.0/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
        6: from (irb):3
        5: from /usr/local/bundle/gems/textrazor-1.1/lib/textrazor/client.rb:37:in `analyse'
        4: from /usr/local/bundle/gems/textrazor-1.1/lib/textrazor/client.rb:37:in `new'
        3: from /usr/local/bundle/gems/textrazor-1.1/lib/textrazor/response.rb:21:in `initialize'
        2: from /usr/local/lib/ruby/2.7.0/json/common.rb:156:in `parse'
        1: from /usr/local/lib/ruby/2.7.0/json/common.rb:156:in `parse'
Traceback (most recent call last):
	17: from /usr/local/bin/irb:23:in `<main>'
	16: from /usr/local/bin/irb:23:in `load'
	15: from /usr/local/lib/ruby/gems/2.7.0/gems/irb-1.2.3/exe/irb:11:in `<top (required)>'
	14: from /usr/local/lib/ruby/2.7.0/irb.rb:399:in `start'
	13: from /usr/local/lib/ruby/2.7.0/irb.rb:470:in `run'
	12: from /usr/local/lib/ruby/2.7.0/irb.rb:470:in `catch'
	11: from /usr/local/lib/ruby/2.7.0/irb.rb:471:in `block in run'
	10: from /usr/local/lib/ruby/2.7.0/irb.rb:536:in `eval_input'
	 9: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:134:in `each_top_level_statement'
	 8: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:134:in `catch'
	 7: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:135:in `block in each_top_level_statement'
	 6: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:135:in `loop'
	 5: from /usr/local/lib/ruby/2.7.0/irb/ruby-lex.rb:150:in `block (2 levels) in each_top_level_statement'
	 4: from /usr/local/lib/ruby/2.7.0/irb.rb:537:in `block in eval_input'
	 3: from /usr/local/lib/ruby/2.7.0/irb.rb:695:in `signal_status'
	 2: from /usr/local/lib/ruby/2.7.0/irb.rb:550:in `block (2 levels) in eval_input'
	 1: from /usr/local/lib/ruby/2.7.0/irb.rb:598:in `handle_exception'
/usr/local/lib/ruby/2.7.0/irb.rb:598:in `split': invalid byte sequence in UTF-8 (ArgumentError)
```

Disabling gzip fixes this problem. Alternative solution can be to handle gzip response correctly.